### PR TITLE
Remove ctx->http_obj call

### DIFF
--- a/src/vmod_header.c
+++ b/src/vmod_header.c
@@ -86,9 +86,6 @@ header_vrt_selecthttp(const struct vrt_ctx *ctx, enum gethdr_e where)
 	case HDR_RESP:
 		hp = ctx->http_resp;
 		break;
-	case HDR_OBJ:
-		hp = ctx->http_obj;
-		break;
 	default:
 		WRONG("vrt_selecthttp 'where' invalid");
 	}


### PR DESCRIPTION
`libvmod-header` doesn't build on Varnish since https://github.com/varnish/Varnish-Cache/commit/f36b47641fad8f6b6bd0f9841e3e3ee16cf6fdeb

This PR reflects these changes and builds fine against latest Varnish master.

It should also build on previous revisions but as it removes functionality, it would be incompatible with VCL using this VMOD on `obj`.

As `vrt.h` major version has been bumped in this commit, maybe you'll want to create a new branch for `libvmod_header` (4.1 or so...).
